### PR TITLE
Add fix for freezing in windowed mode when using Raw Input

### DIFF
--- a/0015-Fix-freezing-when-in-windowed-mode.patch
+++ b/0015-Fix-freezing-when-in-windowed-mode.patch
@@ -1,0 +1,58 @@
+From 22cb9cdc78bb382b895cefff60ab602d43d082b7 Mon Sep 17 00:00:00 2001
+From: Alde Rojas <hello@alde.dev>
+Date: Sat, 14 Oct 2023 00:31:00 -0500
+Subject: [PATCH] Fix freezing when in windowed mode
+
+---
+ WinDrv/Inc/WinDrv.h        | 1 +
+ WinDrv/Src/WinClient.cpp   | 5 +++++
+ WinDrv/Src/WinRawInput.cpp | 5 +++++
+ 3 files changed, 11 insertions(+)
+
+diff --git a/WinDrv/Inc/WinDrv.h b/WinDrv/Inc/WinDrv.h
+index 0d841ad..098a33e 100644
+--- a/WinDrv/Inc/WinDrv.h
++++ b/WinDrv/Inc/WinDrv.h
+@@ -367,6 +367,7 @@ class DLL_EXPORT UWindowsRawInputHandler : public UWindowsInputHandler
+ 	DECLARE_WITHIN(UWindowsRawInput);
+ 
+ 	UBOOL HandleWindowMessage(UINT iMessage, WPARAM wParam, LPARAM lParam);
++	UBOOL SuppressRawMessages();
+ 
+ 	void UpdateInput(FLOAT DeltaSeconds);
+ 	void SetCooperative() { RegisterDevice(true); }
+diff --git a/WinDrv/Src/WinClient.cpp b/WinDrv/Src/WinClient.cpp
+index 4f437cc..404555a 100644
+--- a/WinDrv/Src/WinClient.cpp
++++ b/WinDrv/Src/WinClient.cpp
+@@ -138,6 +138,11 @@ void UWindowsClient::Init( UEngine* InEngine )
+ UBOOL UWindowsClient::SuppressRawMessages()
+ {
+ 	guard(UWindowsClient::SuppressRawMessages);
++	// Delegate to the input handler
++	if (Viewports.Num())
++		return ((UWindowsViewport*)Viewports(0))->InputHandler->SuppressRawMessages();
++
++	// Fallback to input class
+ 	if (Input)
+ 		return Input->SuppressRawMessages();
+ 
+diff --git a/WinDrv/Src/WinRawInput.cpp b/WinDrv/Src/WinRawInput.cpp
+index 64662b6..26fb027 100644
+--- a/WinDrv/Src/WinRawInput.cpp
++++ b/WinDrv/Src/WinRawInput.cpp
+@@ -58,6 +58,11 @@ void UWindowsRawInputHandler::UpdateInput(FLOAT DeltaSeconds)
+ 	unguard;
+ }
+ 
++UBOOL UWindowsRawInputHandler::SuppressRawMessages()
++{
++	return Viewport->IsFullscreen();
++}
++
+ UBOOL UWindowsRawInputHandler::HandleWindowMessage(UINT iMessage, WPARAM wParam, LPARAM lParam)
+ {
+ 	guard(UWindowsRawInputHandler::HandleWindowMessage);
+-- 
+2.31.1.windows.1
+


### PR DESCRIPTION
On Windows 10 and DirectX 8, it appears the input processing is not executed when in windowed mode. This means the message queue is filled with input messages and Windows assumes the application is unresponsive as a result. This fix will re-enable raw input processing in the outer message pump when in windowed mode.